### PR TITLE
Fixed: the handler fails to handle 2XX responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ project.sublime-workspace
 test/static
 coverage/*
 static
+yarn.lock

--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,4 @@ test
 .beans
 .cache
 .git
+yarn.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ChangeLog
 
+## v2.0.2
+Fixed: the handler fails to handle 2XX responses
+
 ## v2.0.1
 Fixed: Should allow different origin when allow origin is *
 

--- a/index.js
+++ b/index.js
@@ -76,6 +76,14 @@ function invoke(options, callback) {
             if (err) {
                 return callback(err);
             }
+            // 3XX responses are treated as error by jsonpipe
+            if (xhr && (xhr.status > 200 && xhr.status < 300)) {
+                resHeaders = resHeaders || (xhr.getAllResponseHeaders() || '');
+                callback(null, {
+                    statusCode: xhr.status,
+                    headers: resHeaders
+                });
+            }
             // only do second callback when it is chunked
             if (_isChunked) {
                 callback(null, {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "test": "./node_modules/mocha/bin/mocha test",
-    "test-coverage": "./node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec"
+
+    "test-coverage": "./node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha -- -R spec"
   },
   "repository": {
     "type": "git",

--- a/test/browser.js
+++ b/test/browser.js
@@ -114,6 +114,20 @@ describe(__filename, function() {
             });
         });
 
+        it('should handle 204 response with no body from POST request', function(done) {
+            this.timeout(30000);
+
+            validateXhr(function validate(ctx) {
+                Assert.equal('<div id="xhr-response">204</div>',
+                    ctx.browser.html('#xhr-response'));
+                Assert.equal(1, ctx.countAjaxRequests);
+                done();
+            }, {
+                buttonName: 'Do Xhr 204 Request',
+                originHost: 'www.some.other.com'
+            });
+        });
+
         it('should format url', function () {
             var url = xhrTransportFactory.Utils.options2Url({
                 method: 'GET',

--- a/test/fixtures/components/app-ajax/index.js
+++ b/test/fixtures/components/app-ajax/index.js
@@ -54,6 +54,9 @@ module.exports = require('marko-widgets').defineComponent({
             else if (!res) {
                 self.setState('response', 'ERROR: unknown');
             }
+            else if (res.statusCode > 200 && res.statusCode < 300) {
+                self.setState('response', res.statusCode);
+            }
             else {
                 self.setState('response', JSON.stringify(res.body));
             }
@@ -83,6 +86,17 @@ module.exports = require('marko-widgets').defineComponent({
         console.log('Making Xhr Post service call...');
         this.makeAjax('xhr', {
             method: 'post'
+        });
+    },
+
+    makeXhr204Call: function(event) {
+        console.log('Making Xhr 204 service call...');
+        this.makeAjax('xhr', {
+            method: 'post',
+            params: {
+                reply204: 'true',
+                originAll: '*'
+            }
         });
     },
 

--- a/test/fixtures/components/app-ajax/template.marko
+++ b/test/fixtures/components/app-ajax/template.marko
@@ -28,6 +28,10 @@
         w-onClick="makeXhrOriginAllCall">
         Do Xhr Origin All Request
     </button>
+    <button type="button"
+        w-onClick="makeXhr204Call">
+        Do Xhr 204 Request
+    </button>
 
     <div>
         total time: ${data.time} ms

--- a/test/fixtures/json/index.js
+++ b/test/fixtures/json/index.js
@@ -5,8 +5,8 @@ module.exports = function json(req, res) {
         return;
     }
 
-    if (req.query.originAll) {
-        res.header('Access-Control-Allow-Origin', req.query.originAll);
+    if (req.query.originAll || req.body && req.body.originAll) {
+        res.header('Access-Control-Allow-Origin', req.query.originAll || req.body.originAll);
     }
     else {
         res.header('Access-Control-Allow-Origin', 'http://www.test.fake-xyz.com');
@@ -30,6 +30,11 @@ module.exports = function json(req, res) {
     var model = {
         message: 'hello world'
     };
+
+    if (req.query.reply204 || req.body && req.body.reply204) {
+        res.status(204).end();
+        return;
+    }
 
     if (/POST|PUT|PATCH/.test(req.method)) {
         res.json(req.body);

--- a/test/invoke.js
+++ b/test/invoke.js
@@ -47,6 +47,19 @@ describe(__filename, function() {
             }));
         });
 
+        it('should process 204 response with no content', function(done) {
+            var xhr = Service.invoke(requestOptions, function (err, res) {
+                assert.ok(!err, err);
+                assert.equal(204, res.statusCode);
+                assert.equal(undefined, res.body);
+                done();
+            });
+
+            xhr.respond(204, {
+                "Content-Type": "application/json"
+            });
+        });
+
         it('should process a JSON response with 1 chunk and ending with \\n\\n', function(done) {
             var count = 1;
             var xhr = Service.invoke(requestOptions, function (err, res) {


### PR DESCRIPTION
The current version of transport does not handle correctly 2xx response that results in no callback fired for  such edge-cases

